### PR TITLE
Add Python 3.12 support

### DIFF
--- a/.github/workflows/lint_checks_and_tests.yml
+++ b/.github/workflows/lint_checks_and_tests.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.12"]
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Minimal Request Finder is a analysis tool to determine the minimum valid API request data (including headers, query params, and payload) required to receive a valid response from an endpoint. It is designed to help in the process of reverse engineering complex third party API's and identifying the smallest, most efficient request that can be made.
+`minimalrequest` is a analysis tool to determine the minimum valid API request data (including headers, query params, and payload) required to receive a valid response from an endpoint. It is designed to help in the process of reverse engineering complex third party API's and identifying the smallest, most efficient request that can be made.
 
 # Installation
 
@@ -10,7 +10,7 @@ pip install minimalrequest
 
 # Methodology
 
-Minimal Request Finder works by applying a simple algorithm to pare down requests.
+`minimalrequest` works by applying a simple algorithm to pare down requests.
 
 1. An initial request is passed that might contain extra headers, query params, or JSON payload data that doesn't effect the value of the JSON response received. A request to that endpoint is made and the response is saved as the "reference" response.
 2. Each request element (this could be a header, query param, or JSON payload property) is removed and a test request is sent.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,3 @@
 pytest==7.4.3
 pytest-mock==3.12.0
-pytest-httpx==0.27.0
+pytest-asyncio==0.21.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,3 @@
 pytest==7.4.3
 pytest-mock==3.12.0
-pytest-asyncio==0.21.1
+pytest-asyncio==0.23.2

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,3 @@
 pytest==7.4.3
 pytest-mock==3.12.0
+pytest-httpx==0.27.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-  "aiohttp==3.8.6",
+  "aiohttp==3.9.1",
   "curlparser==0.1.0"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "Minimal Request Finder is a analysis tool to determine the minimum valid API request data (including headers, query params, and payload) required to receive a valid response from an endpoint. It is designed to help in the process of reverse engineering complex third party API's and identifying the smallest, most efficient request that can be made."
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: Apache Software License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-  "aiohttp==3.9.1",
+  "httpx==0.25.2",
   "curlparser==0.1.0"
 ]
 

--- a/src/minimalrequest/minimal_request.py
+++ b/src/minimalrequest/minimal_request.py
@@ -479,6 +479,10 @@ async def _send_request(
     headers: Headers | None,
     payload: Payload | None,
 ):
+    if headers:
+        for key, value in headers.items():
+            headers[key] = str(value)
+
     if http_method == "get":
         response = await client.get(url=url, headers=headers)
     else:

--- a/src/minimalrequest/minimal_request.py
+++ b/src/minimalrequest/minimal_request.py
@@ -3,7 +3,7 @@ import json
 import sys
 from copy import copy, deepcopy
 from dataclasses import dataclass
-from typing import Any, Callable, Coroutine, Literal, Sequence, TypeVar, cast
+from typing import Any, Callable, Coroutine, Literal, Sequence, cast
 from urllib import parse
 
 import curlparser
@@ -16,7 +16,6 @@ QueryParams = dict[str, Any]
 Headers = dict[str, Any]
 JsonObject = dict[str, Any] | list[Any]
 EquivalencyMode = Literal["exact", "types", "size"]
-_T = TypeVar("_T", QueryParams, Headers, JsonObject)
 
 
 @dataclass
@@ -363,10 +362,10 @@ async def _run(
         return MinimalRequestResult(url, query_params, headers, payload)
 
 
-async def _process_request_element_group(
+async def _process_request_element_group[T: QueryParams | Headers | JsonObject](
     path: Sequence[Any],
-    request_element_group: _T,
-    send_test_request: Callable[[_T], Coroutine[Any, Any, _RequestResult]],
+    request_element_group: T,
+    send_test_request: Callable[[T], Coroutine[Any, Any, _RequestResult]],
     reference_response: JsonObject,
     equivalency_mode: EquivalencyMode,
     size_equivalency_tolerance: float,
@@ -422,11 +421,11 @@ async def _process_request_element_group(
             )
 
 
-async def _request_element_worker(
+async def _request_element_worker[T: QueryParams | Headers | JsonObject](
     rate_limiter: RateLimiter,
     path_to_request_element_to_test: Sequence[Any],
-    request_element_group: _T,
-    send_test_request: Callable[[_T], Coroutine[Any, Any, _RequestResult]],
+    request_element_group: T,
+    send_test_request: Callable[[T], Coroutine[Any, Any, _RequestResult]],
     reference_response: JsonObject,
     equivalency_mode: EquivalencyMode,
     size_equivalency_tolerance: float,


### PR DESCRIPTION
- Support Python >= 3.12.
- Implement new generics syntax.
- Switch to `httpx` for network requests since `aiohttp` is still broken for Windows on Python 3.12.
- Minor doc update.